### PR TITLE
Add trait Status to support customizable healthz and metrics.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -400,6 +400,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
 
 [[package]]
+name = "arc-swap"
+version = "1.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
+
+[[package]]
 name = "argon2"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1372,7 +1378,7 @@ dependencies = [
 
 [[package]]
 name = "externaldns-webhook"
-version = "2024.11.22"
+version = "2025.3.4"
 dependencies = [
  "actix-web",
  "anyhow",
@@ -1381,10 +1387,13 @@ dependencies = [
  "dashmap 6.1.0",
  "either",
  "env_logger",
- "itertools 0.13.0",
+ "itertools 0.14.0",
  "log",
  "logcall",
+ "metrics",
+ "metrics-prometheus",
  "nonempty",
+ "prometheus",
  "regex",
  "serde",
  "serde_json",
@@ -2148,6 +2157,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2414,6 +2432,46 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "metrics"
+version = "0.24.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a7deb012b3b2767169ff203fadb4c6b0b82b947512e5eb9e0b78c2e186ad9e3"
+dependencies = [
+ "ahash 0.8.11",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-prometheus"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b9f065db7255ebf9df44c3ce5654aa6b21d532db099ea25e02102052118a380"
+dependencies = [
+ "arc-swap",
+ "metrics",
+ "metrics-util",
+ "prometheus",
+ "sealed",
+ "smallvec",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbd4884b1dd24f7d6628274a2f5ae22465c337c5ba065ec9b6edccddf8acc673"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.15.2",
+ "metrics",
+ "rand 0.8.5",
+ "rand_xoshiro",
+ "sketches-ddsketch",
+]
 
 [[package]]
 name = "miette"
@@ -2927,6 +2985,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "prometheus"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "protobuf",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "protobuf"
+version = "2.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "106dd99e98437432fed6519dedecfade6a06a73bb7b2a1e019fdd2bee5778d94"
+
+[[package]]
 name = "psl-types"
 version = "2.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3121,6 +3200,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
  "getrandom 0.3.1",
+]
+
+[[package]]
+name = "rand_xoshiro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+dependencies = [
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3602,6 +3690,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
+name = "sealed"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f968c5ea23d555e670b449c1c5e7b2fc399fdaec1d304a17cd48e288abc107"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3760,6 +3859,12 @@ name = "siphasher"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56199f7ddabf13fe5074ce809e7d3f42b42ae711800501b5b16ea82ad029c39d"
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e9a774a6c28142ac54bb25d25562e6bcf957493a184f15ad4eebccb23e410a"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "externaldns-webhook"
-version = "2024.11.22"
+version = "2025.3.4"
 description = "Interface (trait) for ExternalDns webhook."
-edition = "2021"
+edition = "2024"
 license = "BSD-2-Clause"
 homepage = "https://github.com/Magicloud/externaldns-webhook"
 repository = "https://github.com/Magicloud/externaldns-webhook"
@@ -21,24 +21,27 @@ name = "dumb"
 [dependencies]
 actix-web = { version = "4" }
 anyhow = { version = "1.0" }
-tokio = { version = "1.41", features = ["rt"] }
+tokio = { version = "1.44", features = ["rt"] }
 async-trait = { version = "0.1" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0" }
 regex = { version = "1.11" }
 serde_with = { version = "3.12" }
-either = { version = "1.13" }
+either = { version = "1.15" }
 log = { version = "0.4" }
 logcall = { version = "0.1" }
 dashmap = { version = "6.1", features = ["serde"] }
+prometheus = { version="0.13" }
+metrics = { version = "0.24" }
 
 [dev-dependencies]
 env_logger = { version = "0.11" }
 clap = { version = "4.5", features = ["derive"] }
 nonempty = { version = "0.11" }
-surrealdb = { version = "2.1", features = ["kv-surrealkv"] }
-itertools = { version = "0.13" }
+surrealdb = { version = "2.2", features = ["kv-surrealkv"] }
+itertools = { version = "0.14" }
 sha2 = { version = "0.10" }
+metrics-prometheus = { version = "0.9" }
 
 [profile.release]
 strip = true

--- a/examples/dumb/helm-value.yaml
+++ b/examples/dumb/helm-value.yaml
@@ -1,12 +1,18 @@
 policy: sync
 
+serviceMonitor:
+  enabled: true
+  additionalLabels:
+    release: monitoring
+
 provider:
   name: webhook
   webhook:
     imagePullPolicy: Always
     image:
       repository: localhost:5000/dumb_ed
-      tag: "a"
+      tag: "b"
     env:
     - name: RUST_LOG
       value: debug
+    serviceMonitor: {}

--- a/src/changes.rs
+++ b/src/changes.rs
@@ -1,6 +1,6 @@
 use crate::endpoint::Endpoint;
 use serde::{Deserialize, Serialize};
-use serde_with::{serde_as, DefaultOnNull};
+use serde_with::{DefaultOnNull, serde_as};
 
 /// Pair with direction
 #[serde_as]

--- a/src/domain_filter.rs
+++ b/src/domain_filter.rs
@@ -1,6 +1,6 @@
 use regex::Regex;
 use serde::{Deserialize, Serialize};
-use serde_with::{serde_as, skip_serializing_none, DisplayFromStr};
+use serde_with::{DisplayFromStr, serde_as, skip_serializing_none};
 
 /// The way to inform ExternalDNS what kind of domains the DNS service provider
 /// could handle.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,8 +6,9 @@ use serde::{Deserialize, Serialize};
 pub mod changes;
 pub mod domain_filter;
 pub mod endpoint;
-pub mod provider;
-pub mod webhook;
+mod provider;
+mod status;
+mod webhook;
 mod webhook_json;
 
 /// Container of either of the two items.
@@ -23,4 +24,5 @@ enum IDoNotCareWhich<A, B> {
 const MEDIATYPE: &str = "application/external.dns.webhook+json;version=1";
 
 pub use provider::Provider;
+pub use status::Status;
 pub use webhook::Webhook;

--- a/src/status.rs
+++ b/src/status.rs
@@ -1,0 +1,25 @@
+use actix_web::http::StatusCode;
+use async_trait::async_trait;
+use std::fmt::Debug;
+
+// TODO: Support Tracing
+
+/// Definition of the Status interface.
+/// This interface should be implemented by DNS service provider application
+/// to give healthz and metrics information
+#[async_trait]
+pub trait Status: Send + Sync + Debug {
+    /// Return if the service is healthy in general
+    async fn healthz(&self) -> (String, StatusCode) {
+        ("OK".to_string(), StatusCode::OK)
+    }
+    /// Return metrics data for Prometheus
+    async fn metrics(&self) -> (String, StatusCode) {
+        let report = prometheus::TextEncoder::new()
+            .encode_to_string(&prometheus::default_registry().gather());
+        match report {
+            Ok(x) => (x, StatusCode::OK),
+            Err(e) => (format!("{e:?}"), StatusCode::INTERNAL_SERVER_ERROR),
+        }
+    }
+}

--- a/src/webhook_json.rs
+++ b/src/webhook_json.rs
@@ -1,6 +1,6 @@
 use crate::MEDIATYPE;
 use actix_web::{
-    body::EitherBody, error::JsonPayloadError, web::Json, HttpRequest, HttpResponse, Responder,
+    HttpRequest, HttpResponse, Responder, body::EitherBody, error::JsonPayloadError, web::Json,
 };
 use serde::Serialize;
 


### PR DESCRIPTION
By default impl, healthz always alive, metrics returns whatever registered as Prometheus records.